### PR TITLE
Revert get_deliverypoint response to DeliveryPointSchema

### DIFF
--- a/src/amc/api/routes.py
+++ b/src/amc/api/routes.py
@@ -24,7 +24,6 @@ from .schema import (
     PersonalStandingSchema,
     TeamStandingSchema,
     DeliveryPointSchema,
-    DeliveryPointDetailSchema,
     DeliveryJobSchema,
     DeliveryJobSummarySchema,
     LapSectionTimeSchema,
@@ -552,7 +551,7 @@ async def list_deliverypoints(request):
     return [dp async for dp in DeliveryPoint.objects.all()]
 
 
-@deliverypoints_router.get("/{guid}/", response=DeliveryPointDetailSchema)
+@deliverypoints_router.get("/{guid}/", response=DeliveryPointSchema)
 async def get_deliverypoint(request, guid):
     return await DeliveryPoint.objects.aget(guid=guid)
 


### PR DESCRIPTION
## Summary
- Revert `get_deliverypoint` endpoint response schema from `DeliveryPointDetailSchema` back to `DeliveryPointSchema`
- Remove unused `DeliveryPointDetailSchema` import