### PR TITLE
feat: add GET /api/shortcut_zones/ endpoint

### DIFF
--- a/src/amc/api/routes.py
+++ b/src/amc/api/routes.py
@@ -962,3 +962,33 @@ async def list_server_commands(request):
     commands.sort(key=lambda x: (x["category"], x["command"]))
 
     return commands
+
+
+# ═══════════════════════════════════════════════════════════════
+# Shortcut Zones
+# ═══════════════════════════════════════════════════════════════
+
+from .schema import ShortcutZoneSchema
+from amc.models import ShortcutZone
+
+shortcut_zones_router = Router()
+
+
+@shortcut_zones_router.get("/", response=list[ShortcutZoneSchema])
+async def list_shortcut_zones(request):
+    """List all active shortcut zones with polygon coordinates."""
+    zones = ShortcutZone.objects.filter(active=True)
+    result = []
+    async for zone in zones:
+        coords = [
+            [x, y] for x, y in zone.polygon.coords[0]
+        ]
+        result.append(
+            {
+                "id": zone.id,
+                "name": zone.name,
+                "description": zone.description or "",
+                "coordinates": coords,
+            }
+        )
+    return result

--- a/src/amc/api/schema.py
+++ b/src/amc/api/schema.py
@@ -451,3 +451,12 @@ class ServerCommandSchema(Schema):
     description: str
     category: str
     deprecated: bool = False
+
+
+class ShortcutZoneSchema(Schema):
+    """Active shortcut zone with polygon coordinates (SRID 3857)."""
+
+    id: int
+    name: str
+    description: str
+    coordinates: list[list[float]]

--- a/src/amc_backend/api.py
+++ b/src/amc_backend/api.py
@@ -67,3 +67,6 @@ api.add_router("/auth/", "amc.api.auth_routes.auth_router")
 
 # Anti-cheat physics integrity reporting (PoC — observe-only)
 api.add_router("/ac/", "amc.api.anticheat_routes.router")
+
+# Shortcut Zones
+api.add_router("/shortcut_zones/", "amc.api.routes.shortcut_zones_router")


### PR DESCRIPTION
## Summary

- Add `GET /api/shortcut_zones/` endpoint that returns all **active** shortcut zones with polygon coordinates
- New `ShortcutZoneSchema` in the internal API schema
- Polygon coordinates serialized as `[[x, y], ...]` pairs (SRID 3857)

## Changes

- `src/amc/api/schema.py` — `ShortcutZoneSchema` with `id`, `name`, `description`, `coordinates`
- `src/amc/api/routes.py` — `shortcut_zones_router` with `list_shortcut_zones` view
- `src/amc_backend/api.py` — router registration at `/api/shortcut_zones/`

## Example response

```json
[
  {
    "id": 1,
    "name": "Highway Shortcut",
    "description": "Restricted shortcut zone",
    "coordinates": [[x1, y1], [x2, y2], ...]
  }
]
```